### PR TITLE
Dont lookup explicitely for default.yml. Fixes https://github.com/KidkArolis/ava-config/issues/1

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # ava-config
 
+Simple fork of [ava-config](https://github.com/KidkArolis/ava-config) to fix issue [https://github.com/KidkArolis/ava-config/issues/1]
+
 If you're using the [config](https://github.com/lorenwest/node-config) package in your project, you might have run into an issue with [ava](https://github.com/sindresorhus/ava) where your config is not required from the right directory, due to how `ava` is changing `process.cwd` to be the dir of each test.
 
 Prerequiring this package will automagically set `NODE_ENV=test` and `NODE_CONFIG_DIR=closest/config/default.yml`

--- a/index.js
+++ b/index.js
@@ -1,3 +1,4 @@
+
 var fs = require('fs')
 var path = require('path')
 
@@ -20,13 +21,16 @@ function isRoot (dirname) {
   return path.resolve(dirname, '..') === dirname
 }
 
-var configDir = closest(__dirname, 'config/default.yml')
+//start 2 folders up from dirname (which points the ava-config module itself) to avoid looking inside node_modules and finding another folder called config
+var configDir = closest(path.join(__dirname, '../..'), 'config')
 
 if (!configDir.found) {
   console.error('ava-config could not find the config dir.')
   console.error('Paths checked:')
   console.error(configDir.pathsChecked)
   process.exit(1)
+}else{
+    console.log('Found config dir : ', configDir.path)
 }
 
 process.env.NODE_ENV = 'test'

--- a/index.js
+++ b/index.js
@@ -29,8 +29,6 @@ if (!configDir.found) {
   console.error('Paths checked:')
   console.error(configDir.pathsChecked)
   process.exit(1)
-}else{
-    console.log('Found config dir : ', configDir.path)
 }
 
 process.env.NODE_ENV = 'test'


### PR DESCRIPTION
Hi,

The PR looks for a config folder only as opposed to config/default.yml which might not exist if using another file format than yml for the config module configuration.
